### PR TITLE
fix: md文件中本地启动命令修正, package.json文件依赖改变

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn
 
 ### 第三步：本地启动
 ```
-lerna exec --scope mini-vue-devui yarn dev
+lerna exec --scope vue-devui yarn dev
 ```
 
 ## 使用 mini-vue-devui

--- a/package.json
+++ b/package.json
@@ -9,33 +9,6 @@
     "build": "lerna exec --scope vue-devui yarn build",
     "build:lib": "lerna exec --scope vue-devui yarn build:lib"
   },
-  "dependencies": {
-    "vue": "^3.2.16"
-  },
-  "devDependencies": {
-    "@babel/preset-env": "^7.15.8",
-    "@babel/preset-typescript": "^7.15.0",
-    "@types/jest": "^27.0.2",
-    "@vitejs/plugin-vue": "^1.9.3",
-    "@vitejs/plugin-vue-jsx": "^1.2.0",
-    "@vue/babel-plugin-jsx": "^1.1.1",
-    "@vue/test-utils": "^2.0.0-rc.16",
-    "babel-jest": "^27.3.1",
-    "commander": "^8.3.0",
-    "esbuild": "^0.13.10",
-    "fs-extra": "^10.0.0",
-    "inquirer": "^8.2.0",
-    "jest": "^27.3.1",
-    "kolorist": "^1.5.0",
-    "lerna": "^4.0.0",
-    "sass": "^1.43.4",
-    "typescript": "^4.4.3",
-    "vite": "^2.6.4",
-    "vitepress": "^0.20.0",
-    "vitepress-theme-demoblock": "^1.2.6",
-    "vue-template-compiler": "^2.6.14",
-    "vue-tsc": "^0.3.0"
-  },
   "workspaces": [
     "packages/*"
   ],

--- a/packages/devui-cli/package.json
+++ b/packages/devui-cli/package.json
@@ -30,5 +30,13 @@
   "bugs": {
     "url": "https://github.com/57code/mini-vue-devui/issues"
   },
-  "homepage": "https://github.com/57code/mini-vue-devui#readme"
+  "homepage": "https://github.com/57code/mini-vue-devui#readme",
+  "devDependencies": {
+    "commander": "^8.3.0",
+    "esbuild": "^0.13.10",
+    "fs-extra": "^10.0.0",
+    "inquirer": "^8.2.0",
+    "kolorist": "^1.5.0",
+    "lerna": "^4.0.0"
+  }
 }

--- a/packages/devui-vue/package.json
+++ b/packages/devui-vue/package.json
@@ -26,12 +26,7 @@
     "@vue/babel-plugin-jsx": "^1.1.1",
     "@vue/test-utils": "^2.0.0-rc.16",
     "babel-jest": "^27.3.1",
-    "commander": "^8.3.0",
-    "esbuild": "^0.13.10",
-    "fs-extra": "^10.0.0",
-    "inquirer": "^8.2.0",
     "jest": "^27.3.1",
-    "kolorist": "^1.5.0",
     "lerna": "^4.0.0",
     "sass": "^1.43.4",
     "typescript": "^4.4.3",
@@ -41,8 +36,5 @@
     "vue-template-compiler": "^2.6.14",
     "vue-tsc": "^0.3.0"
   },
-  "workspaces": [
-    "packages/*"
-  ],
   "license": "MIT"
 }


### PR DESCRIPTION
md文件中本地启动命令修正
lerna exec --scope mini-vue-devui yarn dev -> lerna exec --scope vue-devui yarn dev

根目录 package.json 删除了开发依赖，
dev-cli的 package.json加入了cli所需的依赖
devui-vuei的 package.json删除了cli所需的依赖